### PR TITLE
Update doc/service.txt

### DIFF
--- a/doc/service.txt
+++ b/doc/service.txt
@@ -28,7 +28,7 @@
     :dependencies       => ['W32Time','Schedule']
     :service_start_name => 'SomeDomain\\User',
     :password           => 'XXXXXXX',
-    :display_name       => 'This is some service',
+    :display_name       => 'This is some service'
   )
     
   # Configure a service that already exists


### PR DESCRIPTION
Removed trailing comma from 'Create a new service' example as currently example will fail if copied.
