### PR TITLE
Add ::delayed_start method

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,6 +69,12 @@ namespace 'test' do
       t.warning = true
       t.test_files = FileList['test/test_win32_service_status.rb']
     end
+
+    Rake::TestTask.new('close_service_handle') do |t|
+      t.verbose = true
+      t.warning = true
+      t.test_files = FileList['test/test_win32_service_close_service_handle.rb']
+    end
   end
 
   task :all do

--- a/lib/win32/service.rb
+++ b/lib/win32/service.rb
@@ -1234,8 +1234,19 @@ module Win32
     rescue SystemCallError
       delayed_start = nil
     ensure
-      CloseServiceHandle(handle_scs) if handle_scs.to_i > 0
-      CloseServiceHandle(handle_scm) if handle_scm.to_i > 0
+      close_service_handle(handle_scs)
+      close_service_handle(handle_scm)
+    end
+
+    def self.close_service_handle(handle)
+      case handle
+      when NilClass
+        false
+      when Integer
+        handle > 0 ? CloseServiceHandle(handle) : false
+      else
+        raise ArgumentError, "You must pass a valid handle to ::close_service_handle"
+      end
     end
 
     private

--- a/lib/win32/service.rb
+++ b/lib/win32/service.rb
@@ -1202,14 +1202,15 @@ module Win32
     # or the local machine if no host is provided.
     #
     # @example Get 'SomeSvc' delayed start on the local machine
-    #    Service.delayed_start('SomeSvc') # => true
+    #    Service.delayed_start('SomeSvc') # => 1
     # @example Get 'SomeSvc' delayed start on host foo
-    #    Service.delayed_start('SomeSvc', 'foo') # => true
+    #    Service.delayed_start('SomeSvc', 'foo') # => 1
     #
     # @param service [String] Service name (e.g. `"Dhcp"`)
     # @param host [String] Host of service (e.g. `"mymachine"`)
-    # @return [Boolean, nil] Returns whether or not delayed start is enabled
-    #   for the service. Returns nil if service does not exist.
+    # @return [Integer, false, nil] Returns `1` when delayed start is enabled
+    #   and `0` when it is not enabled. Returns nil or false when there is
+    #   a problem of some kind.
     #
     def self.delayed_start(service, host = nil)
       handle_scm = OpenSCManager(host, nil, SC_MANAGER_ENUMERATE_SERVICE)
@@ -1227,7 +1228,7 @@ module Win32
       delayed_start_buf = get_config2_info(handle_scs, SERVICE_CONFIG_DELAYED_AUTO_START_INFO)
       if delayed_start_buf.is_a?(FFI::MemoryPointer)
         delayed_start_info = SERVICE_DELAYED_AUTO_START_INFO.new(delayed_start_buf)
-        delayed_start = delayed_start_info[:fDelayedAutostart] == 1 ? true : false
+        delayed_start = delayed_start_info[:fDelayedAutostart] == 1
       else
         delayed_start = false
       end

--- a/test/test_win32_service_close_service_handle.rb
+++ b/test/test_win32_service_close_service_handle.rb
@@ -1,0 +1,28 @@
+########################################################################
+# test_win32_service_close_service_handle.rb
+#
+# Test case for the close_service_handle method
+########################################################################
+require 'test-unit'
+require 'win32/service'
+
+class TC_Win32_Service_CloseServiceHandle < Test::Unit::TestCase
+  def test_service_close_service_handle_returns_false_when_passed_nil
+    assert_equal(false, Win32::Service.close_service_handle(nil))
+  end
+
+  def test_service_close_service_handle_returns_false_when_passed_0
+    assert_equal(false, Win32::Service.close_service_handle(0))
+  end
+
+  def test_service_close_service_handle_returns_true_when_passed_an_open_handle
+    handle_scm = Win32::Service.send(:OpenSCManager, nil, nil, Win32::Service::SC_MANAGER_ENUMERATE_SERVICE)
+    assert_equal(true, Win32::Service.close_service_handle(handle_scm))
+  end
+
+  def test_service_close_service_handle_raises_argument_error_when_passed_a_string
+    assert_raise(ArgumentError.new('You must pass a valid handle to ::close_service_handle')) do
+      Win32::Service.close_service_handle("test")
+    end
+  end
+end


### PR DESCRIPTION
### Description

Enables re-useable code for retrieving a service's delayed start property.

Slight modification to the API, returns a Boolean instead of an Integer. Previously the method could return a `0`, `1`, `false`, or `nil`. For simplicity sake I changed it to just booleans, but this does change the API. If we can't do this just yet I will revert to the previous API.

The actual call under the hood does return a `BOOL` which is an `int`, so I do think it makes sense to convert to a ruby boolean in this library.

```c
typedef struct _SERVICE_DELAYED_AUTO_START_INFO {
  BOOL fDelayedAutostart;
} SERVICE_DELAYED_AUTO_START_INFO, *LPSERVICE_DELAYED_AUTO_START_INFO;
```

https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/ns-winsvc-_service_delayed_auto_start_info

### Issues Resolved

- https://github.com/chef/chef/issues/8195

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
