### PR TITLE
Bugfix: restore original behavior of ::delayed_start

### DIFF
--- a/lib/win32/service.rb
+++ b/lib/win32/service.rb
@@ -1228,7 +1228,7 @@ module Win32
       delayed_start_buf = get_config2_info(handle_scs, SERVICE_CONFIG_DELAYED_AUTO_START_INFO)
       if delayed_start_buf.is_a?(FFI::MemoryPointer)
         delayed_start_info = SERVICE_DELAYED_AUTO_START_INFO.new(delayed_start_buf)
-        delayed_start = delayed_start_info[:fDelayedAutostart] == 1
+        delayed_start = delayed_start_info[:fDelayedAutostart]
       else
         delayed_start = false
       end


### PR DESCRIPTION
### Description

This will restore the original behavior of `::delayed_start`. I noticed I accidentally altered the original behavior of retrieving delayed_start. Compare the following two lines:

1. https://github.com/chef/win32-service/pull/59/files#diff-e6ebb60f864ef419f01ae2c44e247a13L1094
2. https://github.com/chef/win32-service/pull/59/files#diff-e6ebb60f864ef419f01ae2c44e247a13R1231

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
