### PR TITLE
removed secondary SERVICE_STATUS_PROCESS class from structs

### DIFF
--- a/lib/win32/windows/structs.rb
+++ b/lib/win32/windows/structs.rb
@@ -68,20 +68,6 @@ module Windows
       end
     end
 
-    class SERVICE_STATUS_PROCESS < FFI::Struct
-      layout(
-        :dwServiceType, :dword,
-        :dwCurrentState, :dword,
-        :dwControlsAccepted, :dword,
-        :dwWin32ExitCode, :dword,
-        :dwServiceSpecificExitCode, :dword,
-        :dwCheckPoint, :dword,
-        :dwWaitHint, :dword,
-        :dwProcessId, :dword,
-        :dwServiceFlags, :dword
-      )
-    end
-
     class ENUM_SERVICE_STATUS_PROCESS < FFI::Struct
       layout(
         :lpServiceName, :pointer,


### PR DESCRIPTION
### Description

There's currently a duplicate class named SERVICE_STATUS_PROCESS which is causing deprecation warnings as this will be disallowed in ffi-2.0

### Issues Resolved

Resolves the following error message:
`C:/opscode/chef/embedded/lib/ruby/gems/2.6.0/gems/ffi-1.12.1-x64-mingw32/lib/ffi/struct.rb:207:in `layout': [DEPRECATION] Struct layout is already defined for class Windows::ServiceStructs::SERVICE_STATUS_PROCESS. Redefinition as in C:/opscode/chef/embedded/lib/ruby/gems/2.6.0/gems/win32-service-2.1.4/lib/win32/windows/structs.rb:72:in `<class:SERVICE_STATUS_PROCESS>' will be disallowed in ffi-2.0. (StructuredWarnings::StandardWarning)`

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
