### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/win32/windows/functions.rb
+++ b/lib/win32/windows/functions.rb
@@ -1,4 +1,4 @@
-require 'ffi'
+require 'ffi' unless defined?(FFI)
 
 module Windows
   module ServiceFunctions

--- a/lib/win32/windows/structs.rb
+++ b/lib/win32/windows/structs.rb
@@ -1,4 +1,4 @@
-require 'ffi'
+require 'ffi' unless defined?(FFI)
 
 module Windows
   module ServiceStructs


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>