### PR TITLE
daemon: Enable to handle user defined control codes

### DIFF
--- a/doc/daemon.txt
+++ b/doc/daemon.txt
@@ -92,6 +92,9 @@ Daemon#service_paramchange
   Called if the service receives a SERVICE_CONTROL_PARAMCHANGE signal.
   This notifies a service that its startup parameters have changed.
 
+Daemon#service_user_defined_control(code)
+  Called if the service receives a user-defined control code (128 to 255).
+
 = Constants
 
 === Service state constants

--- a/lib/win32/daemon.rb
+++ b/lib/win32/daemon.rb
@@ -304,6 +304,14 @@ module Win32
               when SERVICE_CONTROL_NETBINDDISABLE
                 service_netbinddisable() if respond_to?('service_netbinddisable')
             end
+
+            # handle user defined control codes
+            if @@waiting_control_code >= 128 && @@waiting_control_code <= 255
+              if respond_to?('service_user_defined_control')
+                service_user_defined_control(@@waiting_control_code)
+              end
+            end
+
             @@waiting_control_code = IDLE_CONTROL_CODE
           end
 


### PR DESCRIPTION

### Description

128 to 255 for windows service's control codes are user-defined code:

  * https://docs.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-controlservice

but win32-service doesn't handle these codes.

This commit adds a handler for them.

### Issues Resolved

None.

### Check List

- [ ] New functionality includes tests
  - It doesn't include tests because Daemon's test is rather limited since it's needed to register a windows service for testing actual behavior:  https://github.com/chef/win32-service/blob/bfeaedf6f5f49894161d4def94ce2cbc3042f5ca/test/test_win32_daemon.rb#L7-L8
  - I confirmed this code with https://github.com/fluent/fluentd/pull/3131
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
