### PR TITLE
Replace deprecated --without flag with bundle config

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,7 +10,8 @@ expeditor:
 steps:
 - label: "run specs :windows:"
   command:
-    - bundle install --jobs=7 --retry=3 --without docs debug
+    - bundle config set --local without docs debug
+    - bundle install --jobs=7 --retry=3
     - bundle exec rake spec
   expeditor:
     executor:


### PR DESCRIPTION
Replacing **--without** flag with **bundle config** to get rid of bundler deprecated warning :

[DEPRECATED] The --without flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set without 'development doc', and stop using this flag

Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
