### PR TITLE
daemon: Fix slow start with Ruby 3

### DIFF
--- a/lib/win32/daemon.rb
+++ b/lib/win32/daemon.rb
@@ -186,25 +186,6 @@ module Win32
 
     end
 
-    ThreadProc = FFI::Function.new(:ulong, [:pointer]) do |lpParameter|
-      ste = FFI::MemoryPointer.new(SERVICE_TABLE_ENTRY, 2)
-
-      s = SERVICE_TABLE_ENTRY.new(ste[0])
-      s[:lpServiceName] = FFI::MemoryPointer.from_string("")
-      s[:lpServiceProc] = lpParameter
-
-      s = SERVICE_TABLE_ENTRY.new(ste[1])
-      s[:lpServiceName] = nil
-      s[:lpServiceProc] = nil
-
-      # No service to step, no service handle, no ruby exceptions, just terminate the thread..
-      unless StartServiceCtrlDispatcher(ste)
-        return 1
-      end
-
-      return 0
-    end
-
     # This is a shortcut for Daemon.new + Daemon#mainloop.
     #
     def self.mainloop
@@ -254,26 +235,29 @@ module Win32
         raise SystemCallError.new("CreateEvent", FFI.errno)
       end
 
-      hThread = CreateThread(nil, 0, ThreadProc, Service_Main, 0, nil)
+      hThread = Thread.new(Service_Main) do |lp_proc|
+        ste = FFI::MemoryPointer.new(SERVICE_TABLE_ENTRY, 2)
 
-      if hThread == 0
-        raise SystemCallError.new("CreateThread", FFI.errno)
+        s = SERVICE_TABLE_ENTRY.new(ste[0])
+        s[:lpServiceName] = FFI::MemoryPointer.from_string("")
+        s[:lpServiceProc] = lp_proc
+
+        s = SERVICE_TABLE_ENTRY.new(ste[1])
+        s[:lpServiceName] = nil
+        s[:lpServiceProc] = nil
+
+        # When returning 'false', there is no service to stop, no service handle,
+        # no ruby exceptions, just terminate the thread.
+        StartServiceCtrlDispatcher(ste)
       end
 
-      events = FFI::MemoryPointer.new(:pointer, 2)
-      events.put_pointer(0, FFI::Pointer.new(hThread))
-      events.put_pointer(FFI::Pointer.size, FFI::Pointer.new(@@hStartEvent))
-
-      while (index = WaitForMultipleObjects(2, events, 0, 1000)) == WAIT_TIMEOUT
+      while (index = WaitForSingleObject(@@hStartEvent, 1000)) == WAIT_TIMEOUT
+        # The thread exited, so the show is off.
+        raise "Service_Main thread exited abnormally" unless hThread.alive?
       end
 
       if index == WAIT_FAILED
-        raise SystemCallError.new("WaitForMultipleObjects", FFI.errno)
-      end
-
-      # The thread exited, so the show is off.
-      if index == WAIT_OBJECT_0
-        raise "Service_Main thread exited abnormally"
+        raise SystemCallError.new("WaitForSingleObject", FFI.errno)
       end
 
       thr = Thread.new do

--- a/lib/win32/windows/functions.rb
+++ b/lib/win32/windows/functions.rb
@@ -23,7 +23,6 @@ module Windows
 
     attach_pfunc :CloseHandle, [:handle], :bool
     attach_pfunc :CreateEvent, :CreateEventA, %i{ptr int int str}, :handle
-    attach_pfunc :CreateThread, %i{ptr size_t ptr ptr dword ptr}, :handle, blocking: true
     attach_pfunc :EnterCriticalSection, [:ptr], :void
     attach_pfunc :FormatMessage, :FormatMessageA, %i{ulong ptr ulong ulong str ulong ptr}, :ulong
     attach_pfunc :GetCurrentProcess, [], :handle
@@ -31,7 +30,6 @@ module Windows
     attach_pfunc :LeaveCriticalSection, [:ptr], :void
     attach_pfunc :SetEvent, [:handle], :bool
     attach_pfunc :WaitForSingleObject, %i{handle dword}, :dword, blocking: true
-    attach_pfunc :WaitForMultipleObjects, %i{dword ptr int dword}, :dword
 
     ffi_lib :advapi32
 


### PR DESCRIPTION
### Description

* This just changes to use a Ruby thread instead of `CreateThread`.
  * This solves #84.
* This does not change any specification.
* Looks like #83 is trying to fix the same problem.
  * That means there are now two solutions.
    * This PR: Stop using `CreateThread` Win32 API
    * #83: Inserting `sleep 0.1`

### Issues Resolved

* Fix #84

### Check List

- [x] New functionality includes tests
  * No new functionality.
- [x] All tests pass
  * `Win32::Service::status dhcp status sets service_type to "share process"` fails on the master on my local. All else succeeds.
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

### Comparing the time to start a service

* 2.3.2 (Ruby 3.2.2, Windows 10 Home 64bit, 4 core CPU, 8 logical processors, 16GB RAM)
  * Ave: **11.14 seconds**
  * Data(seconds): [8.0, 17.0, 11.0, 11.0, 16.0, 9.0, 9.0, 15.0, 6.0, 9.0, 12.0, 6.0, 16.0, 9.0, 14.0, 9.0, 7.0, 12.0, 8.0, 9.0, 13.0, 9.0, 15.0, 11.0, 11.0, 8.0, 11.0, 22.0, 11.0, 7.0, 19.0, 11.0, 8.0, 12.0, 9.0]
* Current 2.4.1 (Ruby 3.4.8, Windows 11 Home 64bit, 8 core CPU, 16 logical processors, 64GB RAM)
  * Ave: **37.6 seconds**
  * Data(seconds): [40, 29, 39, 39, 39, 40]
* This PR
  * Ave: **0.6982 seconds**
  * Data(seconds): [0.6772, 0.7022, 0.7018, 0.7012, 0.718, 0.7113, 0.6792, 0.7016, 0.686, 0.6857, 0.6859, 0.7014, 0.701, 0.6794, 0.6861, 0.7019, 0.7171, 0.8173, 0.6702, 0.6874, 0.6868, 0.6859, 0.6873, 0.6861]

Service code:

```rb
require "win32/daemon"

class TestService < Win32::Daemon
  def service_main
    while running?
      sleep 10
    end
  end
end

TestService.new.mainloop
```

Measurement steps are the same as #84.