### PR TITLE
Ci fix on buildkite

### DIFF
--- a/.expeditor/scripts/run_windows_tests.ps1
+++ b/.expeditor/scripts/run_windows_tests.ps1
@@ -27,6 +27,7 @@ ruby --version
 Write-Output "--- Bundle install"
 
 bundle config --local path vendor/bundle
+bundle config set without debug
 bundle lock --add-platform x64-mingw-ucrt
 bundle install --jobs=7 --retry=3
 if (-not $?) { throw "bundle install failed" }

--- a/.expeditor/scripts/run_windows_tests.ps1
+++ b/.expeditor/scripts/run_windows_tests.ps1
@@ -27,6 +27,7 @@ ruby --version
 Write-Output "--- Bundle install"
 
 bundle config --local path vendor/bundle
+bundle lock --add-platform x64-mingw-ucrt
 bundle install --jobs=7 --retry=3
 if (-not $?) { throw "bundle install failed" }
 


### PR DESCRIPTION
### Description

CI on buildkite always fails because of compiling native gems.

### Issues Resolved

* Some dependency introduce native gems, so reduce dependency.
* On testing environment, MSYS was removed, so try to use pre-compiled gems.

Feedback on #85, found CI failures.
Without fixing that failure, could not make forward.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
